### PR TITLE
Prefer the package from mkopinsky/zxcvbn-php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "silverstripe/framework": "^4",
-        "bjeavons/zxcvbn-php": "^0.3.0"
+        "mkopinsky/zxcvbn-php": "*"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "silverstripe/framework": "^4",
-        "mkopinsky/zxcvbn-php": "*"
+        "mkopinsky/zxcvbn-php": "^4"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The original package `bjeavons/zxcvbn-php` has a difference with the original js version `dropbox/zxcvbn`. This causes checks to pass on the frond end while failing in the back end thus giving a frustrating user experience. The fork from mkopinsky fixes this issue and is more actively maintained.